### PR TITLE
Feature/card component

### DIFF
--- a/src/components/Card/Card.styles.ts
+++ b/src/components/Card/Card.styles.ts
@@ -10,9 +10,9 @@ export const Container = styled.div`
   align-items: flex-start;
   gap: var(--Gap-XS, 0.75rem);
   flex-shrink: 0;
-  border-radius: var(--Numbers-Border-Soft, 1.5rem);
+  border-radius: ${theme.borders.soft};
   background: ${theme.colors.grayScale.white};
-  box-shadow: 0 1px 12px 0 rgba(25, 24, 29, 0.10);
+  box-shadow: ${theme.effects.dropShadows.DS200};
 `;
 
 export const Header = styled.h3`
@@ -22,12 +22,22 @@ export const Header = styled.h3`
   margin: 0;
 `;
 
+// 텍스트 + 버튼(별) 프레임
+export const Content = styled.div`
+  display: flex;
+  padding: 0 var(--Gap-S, 1rem);
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex: 1 0 0;
+  align-self: stretch;
+`;
+
 export const Body = styled.p`
   ${theme.fonts.body.l500}
   align-self: stretch;
   color: ${theme.colors.grayScale.black};
   margin: 0;
-  flex: 1 1 auto;
 `;
 
 export const Footer = styled.div`

--- a/src/components/Card/Card.styles.ts
+++ b/src/components/Card/Card.styles.ts
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import { theme } from "@/styles/theme";
+
+export const Container = styled.div`
+  display: flex;
+  width: var(--Component-Width-Medium, 28rem);
+  height: var(--Component-Width-Small, 15.5rem);
+  padding: var(--Gap-M, 1rem);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--Gap-XS, 0.75rem);
+  flex-shrink: 0;
+  border-radius: var(--Numbers-Border-Soft, 1.5rem);
+  background: ${theme.colors.grayScale.white};
+  box-shadow: 0 1px 12px 0 rgba(25, 24, 29, 0.10);
+`;
+
+export const Header = styled.h3`
+  ${theme.fonts.heading.h3}
+  align-self: stretch;
+  color: ${theme.colors.grayScale.black};
+  margin: 0;
+`;
+
+export const Body = styled.p`
+  ${theme.fonts.body.l500}
+  align-self: stretch;
+  color: ${theme.colors.grayScale.black};
+  margin: 0;
+  flex: 1 1 auto;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: flex-end;
+  align-items: center;
+`;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -14,10 +14,12 @@ export default function Card({ header, body, score = 0, variant = "input" }: Car
   return (
     <S.Container>
       <S.Header>{header}</S.Header>
-      <S.Body>{body}</S.Body>
-      <S.Footer>
-        <Score value={score} disabled={isOutput} onChange={isOutput ? undefined : () => {}} />
-      </S.Footer>
+      <S.Content>
+        <S.Body>{body}</S.Body>
+        <S.Footer>
+          <Score value={score} disabled={isOutput} onChange={isOutput ? undefined : () => {}} />
+        </S.Footer>
+      </S.Content>
     </S.Container>
   );
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,23 @@
+import * as S from "./Card.styles";
+import Score from "@/components/Score";
+
+interface CardProps {
+  header: string;
+  body: string;
+  score?: number; // 0~5
+  variant?: "input" | "output"; // output: non-interactive view
+}
+
+export default function Card({ header, body, score = 0, variant = "input" }: CardProps) {
+  const isOutput = variant === "output";
+
+  return (
+    <S.Container>
+      <S.Header>{header}</S.Header>
+      <S.Body>{body}</S.Body>
+      <S.Footer>
+        <Score value={score} disabled={isOutput} onChange={isOutput ? undefined : () => {}} />
+      </S.Footer>
+    </S.Container>
+  );
+}

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Card";

--- a/src/components/Score/Score.styles.ts
+++ b/src/components/Score/Score.styles.ts
@@ -30,12 +30,6 @@ export const StarButton = styled.button<{ $isFilled?: boolean; $disabled?: boole
     width: 1.5rem;
     height: 1.5rem;
     object-fit: contain;
-    ${({ $isFilled }) =>
-      $isFilled
-        ? `
-      filter: brightness(0) saturate(100%) invert(37%) sepia(89%) saturate(2000%) hue-rotate(250deg) brightness(0.9) contrast(1.1);
-    `
-        : ""}
   }
 
   &:disabled {

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { useAuthStore } from "@/stores/authStore";
 import * as S from "./ProfilePage.styles";
 import PMPortfolioForm from "./components/PMPortfolioForm";
-import Score from "@/components/Score";
 
 const PART_OPTIONS = ["PM", "디자인", "프론트엔드", "백엔드"] as const;
 type PartOption = (typeof PART_OPTIONS)[number];
@@ -64,9 +63,6 @@ export default function ProfilePage() {
               프로필 등록
             </S.ProfileActionButton>
           </S.ButtonWrapper>
-          <S.TestSection>
-            <Score value={0} onChange={(v: number) => console.log("Score:", v)} />
-          </S.TestSection>
         </S.ProfileSection>
       </S.Container>
     );


### PR DESCRIPTION
### 공용 Card 컴포넌트 추가
- 레이아웃: display:flex, width: 28rem, height: 15.5rem, padding: Gap/M, gap: Gap/XS, column 정렬
- 스타일: border-radius: theme.borders.soft, background: theme.colors.grayScale.white, box-shadow: theme.effects.dropShadows.DS200
- 텍스트/버튼 프레임(Content): padding: 0 Gap/S, flex-direction: column, justify-content: space-between, align-items: flex-end, flex: 1 0 0, align-self: stretch
- 헤더/바디 타이포: theme.fonts.heading.h3, theme.fonts.body.l500 + theme.colors.grayScale.black
### Score 컴포넌트 연동
- star_filled_purple.svg 사용 
- 버튼 radius/배경/상태 컬러: theme.borders.sharp, theme.colors.grayScale.white, theme.colors.secondary.VT100

### input vs output (적용 시나리오)
- input: 편집/등록 단계. Score가 활성화되어 별 클릭으로 값 변경 가능. 변경값은 부모로 전달해 상태를 업데이트(onScoreChange).
- output: 표시 단계. 상호작용 없음(hover/press/click 미적용). 최종 입력값만 보여줌.

#### 예시 (프로필 페이지)
```
const [isEditMode, setIsEditMode] = useState(true);
const [score, setScore] = useState(0);

// 등록 버튼 클릭 시
const handleRegister = () => {
  // 저장 처리...
  setIsEditMode(false); // 표시 단계로 전환
};

// 입력 단계
<Card
  header="Header"
  body="Body"
  score={score}
  variant={isEditMode ? "input" : "output"}
  onScoreChange={isEditMode ? (v) => setScore(v) : undefined}
/>

// 표시 단계
<Card
  header="Header"
  body="Body"
  score={score}
  variant="output"
/>
```

- variant="input": 별 클릭 가능, onScoreChange(value:number) 콜백으로 부모에서 상태 반영
- variant="output": 클릭 불가(표시 전용), 동일 레이아웃/스타일 유지


wow..전역