### PR TITLE
feat:JoinRoomDefault 페이지 제작

### DIFF
--- a/src/pages/joinroom/JoinRoom.styles.ts
+++ b/src/pages/joinroom/JoinRoom.styles.ts
@@ -1,20 +1,37 @@
 import styled from 'styled-components';
-import { theme } from '../../styles/theme';
+
 
 export const Container = styled.div`
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap; 
-  gap: 0.5rem;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
-  padding: 2rem;
-  background: ${theme.colors.grayScale.white};
-  gap: 1.25rem;
-  overflow: hidden;
-  
-  ${theme.media.mobile} {
-    padding: 1rem;
-  }
+  padding: 7.75rem 2.5rem 0 2.5rem;
+  gap: 10rem;
 `;
+
+export const Title = styled.h2`
+  ${({ theme }) => theme.fonts.heading.h2}
+  color: ${({ theme }) => theme.colors.grayScale.black};
+`;
+
+export const InputArea = styled.div`
+  ${({ theme }) => theme.responsive.property.width('large')}
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const Label = styled.div`
+  ${({ theme }) => theme.fonts.heading.h3}
+  ${({ theme }) => theme.responsive.property.width('min')};
+`;
+
+export const Input = styled.div`
+  width: 100%;
+`;
+
+
+
+

--- a/src/pages/joinroom/JoinRoom.tsx
+++ b/src/pages/joinroom/JoinRoom.tsx
@@ -1,17 +1,36 @@
 import * as S from './JoinRoom.styles'
 
-import RoleTabs from '../../components/Tabs/RoleTabs';
+import { useState } from 'react';
+import { InputField } from '@/components/Input';
+import BlackLTextButton from '@/components/ButtonStatic/BkLTextButton';
+import { useNavigate } from 'react-router-dom';
 
+export default function JoinRoom() {
+  const [text, setText] = useState('');
+  const navigate = useNavigate();
 
-const JoinRoom = () => {
+  const isDisabled = text.trim().length === 0;
+
   return (
     <S.Container>
-        <RoleTabs tabs={['전체', 'PM', '디자인', '프론트엔드', '백엔드']} onChange={(tab) => console.log(tab)} />
+      <S.Title>매칭룸 참여하기</S.Title>
 
+      <S.InputArea>
+        <S.Label>일반 입장 코드</S.Label>
+        <S.Input>
+          <InputField 
+            type="text"
+            placeholder=""
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            hasIcon={false}
+          />
+        </S.Input>
+      </S.InputArea>
 
-
+      <BlackLTextButton disabled={isDisabled} onClick={() => navigate(`/join-room/pr`) }>
+        다음
+      </BlackLTextButton>
     </S.Container>
   );
-};
-
-export default JoinRoom;
+}

--- a/src/pages/joinroom/JoinRoomPR.styles.ts
+++ b/src/pages/joinroom/JoinRoomPR.styles.ts
@@ -48,7 +48,7 @@ export const InputWrapper = styled.div`
 `;
 
 export const Label = styled.h2`
-  ${({ theme }) => theme.fonts.heading.h2}
+  ${({ theme }) => theme.fonts.heading.h3}
   ${({ theme }) => theme.responsive.property.width('min')};
   margin: 0;
   padding:0;


### PR DESCRIPTION
## 📌 Description
[feat] 매칭룸 참여(JoinRoom) 페이지 기본 구현

매칭룸 입장 코드를 입력받는 단일 페이지를 추가
코드 입력 여부에 따라 하단 "다음" 버튼 활성/비활성 및 라우팅 동작을 정의

## 📌 구현 내용

### JoinRoom 페이지 레이아웃 및 인터랙션 동작

1. 컨테이너 / 타이틀
- 피그마 상에서는 padding이 topnav를 포함한 값으로 적용되어 있길래 알아서 top 너비랑 main padding 적용되어 있는거 뺀 값으로 계산해서 넣었는데 요건 틀렸다면 꼭 말해주세요!!!


2. 입장 코드 입력 영역
- 입장 코드에 공백 포함 아무것도 입력 안 하면 버튼이 비활성화 됩니다.

3. 라우팅 동작
- '다음' 버튼 클릭 시 일단 임시로 /join-room/pr 로 이동합니다.
- 추후에 백엔드 연결 이후에 입장 코드 점검이나 프로필 등록 여부 판별해서 모달 띄울 예정입니다.

## 🚀 테스트 방법
- /join-room 경로로 이동


## 🚀 체크리스트
- [x] 인풋이 비어 있거나 공백만 있을 때 "다음" 버튼이 비활성화되는지 확인
- [x] "다음" 버튼 클릭 시 /join-room/pr로 정상 라우팅되는지 확인
- [x] 반응형 구간(모바일/태블릿/데스크톱)에서 InputArea의 width와 정렬이 깨지지 않는지 확인
