### PR TITLE
refactor: rearrange login page container

### DIFF
--- a/src/pages/login/LoginPage.styles.ts
+++ b/src/pages/login/LoginPage.styles.ts
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  display:flex;
-  height: 100%;
+  width: auto;
+  display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding: 0;
 `;
 
 
@@ -13,16 +15,6 @@ export const Title = styled.h1`
   ${({ theme }) => theme.fonts.heading.h1};
   color: ${({ theme }) => theme.colors.grayScale.black};
   text-align: center;
-  margin-bottom: 12.5rem;
-
-  ${({ theme }) => theme.media.desktop} {
-    margin-bottom: 5%;
-  }
-
-  ${({ theme }) => theme.media.tablet} {
-    margin-bottom: 5%;
-  }
-
 `;
 
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -3,12 +3,34 @@ import * as S from './LoginPage.styles';
 
 const LoginPage = () => {
 
-  const REST_API_KEY = '백엔드한테 달라하자1';
-  const REDIRECT_URI = '백엔드한테 달라하자2';
-  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+  // 구글 로그인 설정
+  const GOOGLE_CLIENT_ID = '백엔드한테달라할값';
+  // 배포 시, https://yourdomain.com/oauth2/callback로 변경 (아래 테스트 용)
+  const GOOGLE_REDIRECT_URI = 'http://localhost:5173/oauth2/callback';
+  const GOOGLE_SCOPE = encodeURIComponent(
+  'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile'
+);
+
+const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=${GOOGLE_SCOPE}`;
+
+  // 카카오 로그인 설정
+  const KAKAO_REST_API_KEY = '백엔드한테 달라하자3';
+  const KAKAO_REDIRECT_URI = '백엔드한테 달라하자4';
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+
+
+  const handleGoogleLogin = async () => {
+    window.location.href = googleAuthUrl;
+    // try {
+    //   await socialLogin('google');
+    //   navigate('/home');
+    // } catch (error) {
+    //   console.error('구글 로그인 실패:', error);
+    // }
+  };
 
   const handleKakaoLogin = async () => {
-    window.location.href = link;
+    window.location.href = kakaoAuthUrl;
     // try {
     //   await socialLogin('kakao');
     //   navigate('/home');
@@ -23,7 +45,7 @@ const LoginPage = () => {
         <S.Title>로그인</S.Title>
 
         <S.SocialButtonGroup>
-          <SocialLoginButton provider="google" onClick={handleKakaoLogin}>
+          <SocialLoginButton provider="google" onClick={handleGoogleLogin}>
             Google 로그인
           </SocialLoginButton>
           <SocialLoginButton provider="kakao" onClick={handleKakaoLogin}>


### PR DESCRIPTION
# Description
- 상위 레이아웃 파일을 수정하면서 깨진 로그인 페이지 내 컨테이너 레이아웃 수정
- 구글 로그인 (원래 카카오로 연결되어 있었음) -> 구글 페이지로 연결되게 설정 (API 연결 없이, 프론트 상에서 url 작동만 확인가능)

# Test
- 반응형 동작 여부
- 구글 로그인 선택시 -> google 관련 url 이동