### PR TITLE
feat: add Profile api

### DIFF
--- a/src/components/profile/DesignPortfolioForm.tsx
+++ b/src/components/profile/DesignPortfolioForm.tsx
@@ -6,6 +6,7 @@ import type { SelfAssessmentItem } from "./SelfAssessmentGroup";
 import * as S from "./DesignPortfolioForm.styles";
 import WtLCloseButton from "@/components/ButtonDynamic/WtLCloseButton";
 import UploadIcon from "@/assets/icons/Upload.svg";
+import { updateProfile, createProfile, getProfile } from "@/services/profile";
 
 const FIGMA_ITEMS: SelfAssessmentItem[] = [
   {
@@ -107,7 +108,19 @@ export default function DesignPortfolioForm({
   );
   const isSelfAssessmentValid = isFigmaAssessmentComplete;
 
-  const handleRegister = (isNewcomerValue: boolean) => {
+  // 자가평가 점수의 평균 계산
+  const calculateAverage = (assessments: Record<string, number>, items: readonly SelfAssessmentItem[]): number => {
+    const scores = items
+      .map((item) => assessments[item.key] ?? 0)
+      .filter((score) => score > 0);
+    if (scores.length === 0) return 0;
+    const sum = scores.reduce((acc, score) => acc + score, 0);
+    const average = sum / scores.length;
+    // 0.5 단위로 내림
+    return Math.floor(average * 2) / 2;
+  };
+
+  const handleRegister = async (isNewcomerValue: boolean) => {
     // 등록 버튼 클릭 시 파트 추가를 위해 부모 컴포넌트에 알림
     let updatedSelectedParts = currentSelectedParts;
     if (onRegister) {
@@ -119,6 +132,72 @@ export default function DesignPortfolioForm({
       updatedSelectedParts = currentSelectedParts.includes("디자인") 
         ? currentSelectedParts 
         : [...currentSelectedParts, "디자인"];
+    }
+
+    // 공통 프로필이 없으면 먼저 생성
+    if (name || intro) {
+      const commonProfileResult = await updateProfile({
+        username: name,
+        comment: intro,
+      });
+      
+      if (!commonProfileResult.success) {
+        console.error("공통 프로필 생성/업데이트 실패:", commonProfileResult.error);
+        // 공통 프로필 생성 실패해도 계속 진행 (이미 존재할 수 있음)
+      }
+    }
+
+    // API 요청 데이터 준비
+    const designScore = calculateAverage(figmaAssessment, FIGMA_ITEMS);
+    
+    // multipart/form-data는 파일이 아니면 모두 문자열로 보내야 함
+    // 항상 FormData 사용
+    const formData = new FormData();
+    
+    // 모든 필드를 문자열로 FormData에 추가 (백엔드 구현 방식에 맞게)
+    // 신입이 아니고 experienceSummary가 있으면 추가
+    if (!isNewcomerValue && experienceSummary) {
+      formData.append("experienced", experienceSummary);
+    }
+    // 신입인 경우 experienced 필드를 보내지 않음 (서버에서 처리)
+    
+    formData.append("strength", strengths || "");
+    formData.append("design_score", String(designScore));
+    
+    // portfolio_url 처리: 파일이 있으면 파일 객체, 없으면 문자열(기존 URL 또는 빈 문자열)
+    if (designWorkFile) {
+      // 새로 업로드한 파일이 있는 경우
+      formData.append("portfolio_url", designWorkFile);
+    } else if (designWorkFileName) {
+      // 기존 파일이 있는 경우 (수정 모드에서 파일을 변경하지 않은 경우)
+      // multipart/form-data에서는 파일이 아니면 문자열로 보내야 함
+      formData.append("portfolio_url", designWorkFileName);
+    } else {
+      // 파일이 없는 경우에도 빈 문자열을 보내서 오류 방지
+      formData.append("portfolio_url", "");
+    }
+    
+    console.log("FormData 내용 확인:");
+    for (const [key, value] of formData.entries()) {
+      console.log(key, value instanceof File ? `File: ${value.name}` : value);
+    }
+    
+    // 프로필 존재 여부 확인
+    const existingProfile = await getProfile("DE");
+    let result;
+    
+    if (existingProfile.success && existingProfile.data) {
+      // 프로필이 있으면 PUT (업데이트)
+      result = await updateProfile(formData, "DE");
+    } else {
+      // 프로필이 없으면 POST (생성)
+      result = await createProfile(formData, "DE");
+    }
+    
+    if (!result.success) {
+      // TODO: 에러 처리 (토스트 메시지 등)
+      console.error("프로필 저장 실패:", result.error);
+      return;
     }
     
     // 디자인 포트폴리오 데이터를 localStorage에 저장

--- a/src/components/profile/FrontendPortfolioForm.tsx
+++ b/src/components/profile/FrontendPortfolioForm.tsx
@@ -9,6 +9,7 @@ import {
   FRONTEND_TECH_ITEMS_MAP,
   type FrontendTech,
 } from "@/constants/profile/frontendAssessmentItems";
+import { updateProfile, createProfile, getProfile } from "@/services/profile";
 
 const TECH_ITEMS_MAP = FRONTEND_TECH_ITEMS_MAP;
 
@@ -127,7 +128,7 @@ export default function FrontendPortfolioForm({
 
   const isFormValid = selectedTechs.length > 0 && isAssessmentComplete;
 
-  const handleRegister = (isNewcomerValue: boolean) => {
+  const handleRegister = async (isNewcomerValue: boolean) => {
     let updatedSelectedParts = currentSelectedParts;
     if (onRegister) {
       updatedSelectedParts = onRegister();
@@ -135,6 +136,72 @@ export default function FrontendPortfolioForm({
       updatedSelectedParts = currentSelectedParts.includes("프론트엔드")
         ? currentSelectedParts
         : [...currentSelectedParts, "프론트엔드"];
+    }
+
+    // 공통 프로필이 없으면 먼저 생성
+    if (name || intro) {
+      const commonProfileResult = await updateProfile({
+        username: name,
+        comment: intro,
+      });
+      
+      if (!commonProfileResult.success) {
+        console.error("공통 프로필 생성/업데이트 실패:", commonProfileResult.error);
+        // 공통 프로필 생성 실패해도 계속 진행 (이미 존재할 수 있음)
+      }
+    }
+
+    // techAssessments를 development_score 배열 형식으로 변환
+    const developmentScore: [string, number][] = [];
+    selectedTechs.forEach((tech) => {
+      const assessments = techAssessments[tech] || {};
+      const items = TECH_ITEMS_MAP[tech];
+      if (items && items.length > 0) {
+        // 각 기술별로 평균 점수 계산
+        const scores = items
+          .map((item) => assessments[item.key] ?? 0)
+          .filter((score) => score > 0);
+        if (scores.length > 0) {
+          const average = scores.reduce((acc, score) => acc + score, 0) / scores.length;
+          // 0.5 단위로 내림
+          const roundedAverage = Math.floor(average * 2) / 2;
+          developmentScore.push([tech, roundedAverage]);
+        }
+      }
+    });
+
+    // API 요청 데이터 준비 (JSON 형식)
+    const requestData: {
+      experienced?: string | null;
+      strength?: string | string[];
+      github_url?: string;
+      development_score?: [string, number][];
+    } = {
+      // 신입인 경우 null, 아니면 experienceSummary 전송 (빈 문자열은 제외)
+      ...(isNewcomerValue 
+        ? { experienced: null } 
+        : experienceSummary ? { experienced: experienceSummary } : {}),
+      strength: strengths || "",
+      github_url: github,
+      development_score: developmentScore,
+    };
+
+    // 프로필 존재 여부 확인
+    const existingProfile = await getProfile("FE");
+    let result;
+    
+    if (existingProfile.success && existingProfile.data) {
+      // 프로필이 있으면 PUT (업데이트)
+      result = await updateProfile(requestData, "FE");
+    } else {
+      // 프로필이 없으면 POST (생성)
+      result = await createProfile(requestData, "FE");
+    }
+    
+    if (!result.success) {
+      // TODO: 에러 처리 (토스트 메시지 등)
+      console.error("프로필 저장 실패:", result.error);
+      return;
     }
 
     const frontendData = {

--- a/src/components/profile/PMPortfolioForm.tsx
+++ b/src/components/profile/PMPortfolioForm.tsx
@@ -7,6 +7,7 @@ import type {
   DailyAvailabilityKey,
   WeeklyAvailabilityKey,
 } from "./BasePortfolioForm";
+import { updateProfile, createProfile, getProfile } from "@/services/profile";
 
 const DESIGN_ITEMS: SelfAssessmentItem[] = [
   {
@@ -145,7 +146,40 @@ export default function PMPortfolioForm({
   );
   const isSelfAssessmentValid = isDesignAssessmentComplete && isDevelopmentAssessmentComplete;
 
-  const handleRegister = (isNewcomerValue: boolean) => {
+  // daily/weekly availability를 숫자로 변환
+  const convertDailyAvailabilityToNumber = (key: DailyAvailabilityKey | null): number => {
+    if (!key) return 0;
+    const map: Record<DailyAvailabilityKey, number> = {
+      under1h: 1,
+      "1to3h": 3,
+      over3h: 5,
+    };
+    return map[key];
+  };
+
+  const convertWeeklyAvailabilityToNumber = (key: WeeklyAvailabilityKey | null): number => {
+    if (!key) return 0;
+    const map: Record<WeeklyAvailabilityKey, number> = {
+      under10h: 10,
+      "10to20h": 20,
+      over20h: 30,
+    };
+    return map[key];
+  };
+
+  // 자가평가 점수의 평균 계산
+  const calculateAverage = (assessments: Record<string, number>, items: readonly SelfAssessmentItem[]): number => {
+    const scores = items
+      .map((item) => assessments[item.key] ?? 0)
+      .filter((score) => score > 0);
+    if (scores.length === 0) return 0;
+    const sum = scores.reduce((acc, score) => acc + score, 0);
+    const average = sum / scores.length;
+    // 0.5 단위로 내림
+    return Math.floor(average * 2) / 2;
+  };
+
+  const handleRegister = async (isNewcomerValue: boolean) => {
     // 등록 버튼 클릭 시 파트 추가를 위해 부모 컴포넌트에 알림
     let updatedSelectedParts = currentSelectedParts;
     if (onRegister) {
@@ -157,6 +191,62 @@ export default function PMPortfolioForm({
       updatedSelectedParts = currentSelectedParts.includes("PM") 
         ? currentSelectedParts 
         : [...currentSelectedParts, "PM"];
+    }
+
+    // 공통 프로필이 없으면 먼저 생성
+    if (name || intro) {
+      const commonProfileResult = await updateProfile({
+        username: name,
+        comment: intro,
+      });
+      
+      if (!commonProfileResult.success) {
+        console.error("공통 프로필 생성/업데이트 실패:", commonProfileResult.error);
+        // 공통 프로필 생성 실패해도 계속 진행 (이미 존재할 수 있음)
+      }
+    }
+
+    // API 요청 데이터 준비 (JSON 형식)
+    const designUnderstanding = calculateAverage(designAssessment, DESIGN_ITEMS);
+    const developmentUnderstanding = calculateAverage(developmentAssessment, DEVELOPMENT_ITEMS);
+    
+    const requestData: {
+      experienced?: string | null;
+      strength?: string | string[];
+      daily_time_capacity?: number;
+      weekly_time_capacity?: number;
+      design_understanding?: number;
+      development_understanding?: number;
+    } = {
+      // 신입인 경우 null, 아니면 experienceSummary 전송 (빈 문자열은 제외)
+      ...(isNewcomerValue 
+        ? { experienced: null } 
+        : experienceSummary ? { experienced: experienceSummary } : {}),
+      strength: strengths || "",
+      daily_time_capacity: convertDailyAvailabilityToNumber(dailyAvailability),
+      weekly_time_capacity: convertWeeklyAvailabilityToNumber(weeklyAvailability),
+      design_understanding: designUnderstanding,
+      development_understanding: developmentUnderstanding,
+    };
+
+    console.log("PM 프로필 요청 데이터:", JSON.stringify(requestData, null, 2));
+    
+    // 프로필 존재 여부 확인
+    const existingProfile = await getProfile("PM");
+    let result;
+    
+    if (existingProfile.success && existingProfile.data) {
+      // 프로필이 있으면 PUT (업데이트)
+      result = await updateProfile(requestData, "PM");
+    } else {
+      // 프로필이 없으면 POST (생성)
+      result = await createProfile(requestData, "PM");
+    }
+    
+    if (!result.success) {
+      // TODO: 에러 처리 (토스트 메시지 등)
+      console.error("프로필 저장 실패:", result.error);
+      return;
     }
     
     // PM 포트폴리오 데이터를 localStorage에 저장

--- a/src/lib/AxiosInstance.ts
+++ b/src/lib/AxiosInstance.ts
@@ -13,11 +13,22 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (config) => {
+    // FormData인 경우 Content-Type을 제거 (브라우저가 자동으로 boundary 포함하여 설정)
+    if (config.data instanceof FormData) {
+      delete config.headers['Content-Type'];
+    }
+    
     // 로컬 스토리지에서 토큰 가져오기
     const token = localStorage.getItem('access_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
+      console.log("Authorization 헤더 설정됨:", `Bearer ${token.substring(0, 20)}...`);
+    } else {
+      console.warn("토큰이 없습니다. 인증이 필요할 수 있습니다.");
     }
+    console.log("요청 URL:", config.url);
+    console.log("요청 메서드:", config.method?.toUpperCase());
+    console.log("요청 헤더:", config.headers);
     return config;
   },
   (error) => {

--- a/src/lib/AxiosInstance.ts
+++ b/src/lib/AxiosInstance.ts
@@ -22,13 +22,7 @@ axiosInstance.interceptors.request.use(
     const token = localStorage.getItem('access_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
-      console.log("Authorization 헤더 설정됨:", `Bearer ${token.substring(0, 20)}...`);
-    } else {
-      console.warn("토큰이 없습니다. 인증이 필요할 수 있습니다.");
     }
-    console.log("요청 URL:", config.url);
-    console.log("요청 메서드:", config.method?.toUpperCase());
-    console.log("요청 헤더:", config.headers);
     return config;
   },
   (error) => {

--- a/src/pages/profile/ProfileDefaultPage.tsx
+++ b/src/pages/profile/ProfileDefaultPage.tsx
@@ -5,6 +5,10 @@ import PMPortfolioView from "@/components/profile/PMPortfolioView";
 import DesignPortfolioView from "@/components/profile/DesignPortfolioView";
 import FrontendPortfolioView from "@/components/profile/FrontendPortfolioView";
 import BackendPortfolioView from "@/components/profile/BackendPortfolioView";
+import PMPortfolioForm from "@/components/profile/PMPortfolioForm";
+import DesignPortfolioForm from "@/components/profile/DesignPortfolioForm";
+import FrontendPortfolioForm from "@/components/profile/FrontendPortfolioForm";
+import BackendPortfolioForm from "@/components/profile/BackendPortfolioForm";
 import DBTIResultPage from "./edit/DBTI/DBTIResultPage";
 import * as S from "./ProfilePage.styles";
 import BkMTextButton from "@/components/ButtonStatic/BkMTextButton";
@@ -14,6 +18,9 @@ import type {
   DailyAvailabilityKey,
   WeeklyAvailabilityKey,
 } from "@/components/profile/BasePortfolioForm";
+import { getProfile } from "@/services/profile";
+import { FRONTEND_TECH_ITEMS_MAP } from "@/constants/profile/frontendAssessmentItems";
+import { BACKEND_TECH_ITEMS_MAP } from "@/constants/profile/backendAssessmentItems";
 
 const PART_OPTIONS = ["PM", "디자인", "프론트엔드", "백엔드"] as const;
 type PartOption = (typeof PART_OPTIONS)[number];
@@ -37,6 +44,8 @@ interface PortfolioData {
   dbtiInfo?: string | null;
   profileImage?: string | null;
   selectedParts?: PartOption[];
+  partProfiles?: Record<string, any>; // 서버에서 가져온 각 파트별 프로필 데이터
+  commonProfile?: any; // 공통 프로필 데이터
 }
 
 export default function ProfileDefaultPage() {
@@ -47,6 +56,12 @@ export default function ProfileDefaultPage() {
   const [showDBTIResult, setShowDBTIResult] = useState(false);
   const [selectedPart, setSelectedPart] = useState<PartOption | null>(null);
   const [showRightPanel, setShowRightPanel] = useState(false); // 모바일에서 right panel 표시 여부
+  const [isEditMode, setIsEditMode] = useState<Record<PartOption, boolean>>({
+    PM: false,
+    디자인: false,
+    프론트엔드: false,
+    백엔드: false,
+  }); // 각 파트별 수정 모드 상태
   
   // localStorage에서 저장된 모든 파트의 포트폴리오 데이터 가져오기
   const getStoredPortfolioData = (partName: string): any => {
@@ -114,10 +129,92 @@ export default function ProfileDefaultPage() {
   };
 
   const profileInfo = getProfileInfo();
-  const name = profileInfo.name;
-  const intro = profileInfo.intro;
-  const dbtiInfo = profileInfo.dbtiInfo;
-  const profileImage = profileInfo.profileImage;
+  const [name, setName] = useState(profileInfo.name);
+  const [intro, setIntro] = useState(profileInfo.intro);
+  const [dbtiInfo, setDbtiInfo] = useState(profileInfo.dbtiInfo);
+  const [profileImage, setProfileImage] = useState(profileInfo.profileImage);
+  // 서버에서 가져온 각 파트별 프로필 데이터 저장
+  const [partProfiles, setPartProfiles] = useState<Record<string, any>>(
+    portfolioData?.partProfiles || {}
+  );
+  
+  // location.state에서 서버 데이터가 있으면 사용
+  useEffect(() => {
+    if (portfolioData?.partProfiles && portfolioData?.commonProfile) {
+      setName(portfolioData.commonProfile.username || profileInfo.name);
+      setIntro(portfolioData.commonProfile.comment || profileInfo.intro);
+      setPartProfiles(portfolioData.partProfiles);
+      
+      // available_parts를 selectedParts에 반영
+      if (portfolioData.commonProfile.available_parts && portfolioData.commonProfile.available_parts.length > 0) {
+        const partMap: Record<string, PartOption> = {
+          'PM': 'PM',
+          'FE': '프론트엔드',
+          'BE': '백엔드',
+          'DE': '디자인'
+        };
+        const mappedParts = (portfolioData.commonProfile.available_parts as string[])
+          .map((part: string) => partMap[part])
+          .filter((part): part is PartOption => part !== undefined);
+        if (mappedParts.length > 0) {
+          setSelectedParts(mappedParts);
+        }
+      }
+    }
+  }, [portfolioData]);
+  
+  // 프로필 페이지 로드 시 API에서 프로필 데이터 가져오기 (location.state에 데이터가 없을 때만)
+  useEffect(() => {
+    if (portfolioData?.partProfiles) {
+      // 이미 서버 데이터가 있으면 API 호출하지 않음
+      return;
+    }
+    
+    const loadProfile = async () => {
+      try {
+        // 공통 프로필 가져오기
+        const commonProfileResult = await getProfile();
+        if (commonProfileResult.success && commonProfileResult.data) {
+          const profileData = commonProfileResult.data;
+          setName(profileData.username || profileInfo.name);
+          setIntro(profileData.comment || profileInfo.intro);
+          // available_parts를 selectedParts에 반영
+          if (profileData.available_parts && profileData.available_parts.length > 0) {
+            const partMap: Record<string, PartOption> = {
+              'PM': 'PM',
+              'FE': '프론트엔드',
+              'BE': '백엔드',
+              'DE': '디자인'
+            };
+            const mappedParts = profileData.available_parts
+              .map(part => partMap[part])
+              .filter((part): part is PartOption => part !== undefined);
+            if (mappedParts.length > 0) {
+              setSelectedParts(mappedParts);
+            }
+            
+            // available_parts의 각 파트별 프로필 가져오기
+            const partProfilesData: Record<string, any> = {};
+            for (const part of profileData.available_parts) {
+              try {
+                const partProfileResult = await getProfile(part);
+                if (partProfileResult.success && partProfileResult.data) {
+                  console.log(`${part} 프로필:`, partProfileResult.data);
+                  partProfilesData[part] = partProfileResult.data;
+                }
+              } catch (error) {
+                console.error(`${part} 프로필 로드 실패:`, error);
+              }
+            }
+            setPartProfiles(partProfilesData);
+          }
+        }
+      } catch (error) {
+        console.error("프로필 로드 실패:", error);
+      }
+    };
+    loadProfile();
+  }, []); // 컴포넌트 마운트 시 한 번만 실행
   
   // 초기 선택된 파트 설정 (저장된 첫 번째 파트 또는 location.state의 파트)
   useEffect(() => {
@@ -141,32 +238,12 @@ export default function ProfileDefaultPage() {
       return;
     }
     
-    // 선택된 파트가 있으면 해당 파트의 view 페이지로 이동 (수정/삭제 버튼이 있는 상태)
+    // 선택된 파트가 있으면 해당 파트의 수정 모드로 전환
     if (selectedPart) {
-      const partMap: Record<PartOption, string> = {
-        'PM': 'pm',
-        '디자인': 'design',
-        '프론트엔드': 'frontend',
-        '백엔드': 'backend'
-      };
-      const partSlug = partMap[selectedPart];
-      
-      // localStorage에서 해당 파트의 포트폴리오 데이터 가져오기
-      const partData = getStoredPortfolioData(selectedPart);
-      
-      if (partData) {
-        // 저장된 데이터와 함께 view 페이지로 이동
-        navigate(`/profile/${partSlug}/view`, {
-          state: {
-            ...partData,
-            part: selectedPart,
-            selectedParts: selectedParts
-          }
-        });
-      } else {
-        // 데이터가 없으면 edit 페이지로 이동
-        navigate(`/profile/edit/${partSlug}`);
-      }
+      setIsEditMode((prev) => ({
+        ...prev,
+        [selectedPart]: true,
+      }));
       return;
     }
     
@@ -259,6 +336,117 @@ export default function ProfileDefaultPage() {
     // setIsPartDropdownOpen(false); // TODO: 구현 필요
   };
 
+  // 서버 데이터를 View 컴포넌트 형식으로 변환하는 함수
+  const convertServerDataToViewData = (part: PartOption, serverData: Record<string, any>) => {
+    const reversePartMap: Record<PartOption, "PM" | "FE" | "BE" | "DE"> = {
+      'PM': 'PM',
+      '프론트엔드': 'FE',
+      '백엔드': 'BE',
+      '디자인': 'DE'
+    };
+    
+    const serverPart = reversePartMap[part];
+    const profile = serverData[serverPart];
+    
+    if (!profile) return null;
+    
+    switch (part) {
+      case "PM":
+        // DESIGN_ITEMS와 DEVELOPMENT_ITEMS의 key 목록 (PMPortfolioView와 동일)
+        const DESIGN_ITEMS_KEYS = ["uxFlow", "visualStructure", "designIntent", "communication", "priority"];
+        const DEVELOPMENT_ITEMS_KEYS = ["techStructure", "techContext", "executionSense", "devCommunication", "problemSolving"];
+        
+        // 서버에서 받은 평균 점수를 각 항목에 동일하게 할당
+        const designAssessment: Record<string, number> = {};
+        const developmentAssessment: Record<string, number> = {};
+        
+        if (profile.design_understanding !== undefined && profile.design_understanding !== null) {
+          DESIGN_ITEMS_KEYS.forEach(key => {
+            designAssessment[key] = profile.design_understanding;
+          });
+        }
+        
+        if (profile.development_understanding !== undefined && profile.development_understanding !== null) {
+          DEVELOPMENT_ITEMS_KEYS.forEach(key => {
+            developmentAssessment[key] = profile.development_understanding;
+          });
+        }
+        
+        return {
+          experienceSummary: profile.experienced || "",
+          strengths: profile.strength || "",
+          dailyAvailability: profile.daily_time_capacity ? 
+            (profile.daily_time_capacity <= 1 ? "under1h" as DailyAvailabilityKey : 
+             profile.daily_time_capacity <= 3 ? "1to3h" as DailyAvailabilityKey : "over3h" as DailyAvailabilityKey) : null,
+          weeklyAvailability: profile.weekly_time_capacity ? 
+            (profile.weekly_time_capacity <= 10 ? "under10h" as WeeklyAvailabilityKey : 
+             profile.weekly_time_capacity <= 20 ? "10to20h" as WeeklyAvailabilityKey : "over20h" as WeeklyAvailabilityKey) : null,
+          designAssessment,
+          developmentAssessment,
+          isNewcomer: !profile.experienced || profile.experienced === "",
+        };
+      case "프론트엔드":
+      case "백엔드":
+        // development_score를 techAssessments 형식으로 변환
+        const techAssessments: Record<string, Record<string, number>> = {};
+        const selectedTechs: string[] = [];
+        
+        // 파트에 맞는 TECH_ITEMS_MAP 선택
+        const TECH_ITEMS_MAP: Record<string, any[]> = part === "프론트엔드" ? FRONTEND_TECH_ITEMS_MAP : BACKEND_TECH_ITEMS_MAP;
+        
+        if (profile.development_score && Array.isArray(profile.development_score)) {
+          profile.development_score.forEach(([tech, score]: [string, number]) => {
+            selectedTechs.push(tech);
+            
+            // 해당 기술의 세부 항목들을 가져와서 평균 점수를 각 항목에 할당
+            const techKey = tech as keyof typeof TECH_ITEMS_MAP;
+            const items = TECH_ITEMS_MAP[techKey] as { key: string }[] | undefined;
+            
+            if (items && Array.isArray(items) && items.length > 0) {
+              const assessment: Record<string, number> = {};
+              items.forEach((item: { key: string }) => {
+                assessment[item.key] = score; // 평균 점수를 각 세부 항목에 할당
+              });
+              techAssessments[tech] = assessment;
+            } else {
+              // 항목이 없으면 빈 객체로 설정
+              techAssessments[tech] = {};
+            }
+          });
+        }
+        return {
+          experienceSummary: profile.experienced || "",
+          strengths: profile.strength || "",
+          github: profile.github_url || "",
+          selectedTechs,
+          techAssessments,
+          isNewcomer: !profile.experienced || profile.experienced === "",
+        };
+      case "디자인":
+        // FIGMA_ITEMS의 key 목록 (DesignPortfolioView와 동일)
+        const FIGMA_ITEMS_KEYS = ["uxPlanning", "designConsistency", "collaborationAttitude", "collaborationFeatures", "communicationClarity"];
+        
+        // 서버에서 받은 평균 점수를 각 항목에 동일하게 할당
+        const figmaAssessment: Record<string, number> = {};
+        
+        if (profile.design_score !== undefined && profile.design_score !== null) {
+          FIGMA_ITEMS_KEYS.forEach(key => {
+            figmaAssessment[key] = profile.design_score;
+          });
+        }
+        
+        return {
+          experienceSummary: profile.experienced || "",
+          strengths: profile.strength || "",
+          designWorkFile: profile.portfolio_url || null,
+          figmaAssessment,
+          isNewcomer: !profile.experienced || profile.experienced === "",
+        };
+      default:
+        return null;
+    }
+  };
+
   const renderPortfolioView = () => {
     // DBTI 결과를 표시해야 하는 경우
     if (showDBTIResult) {
@@ -270,13 +458,139 @@ export default function ProfileDefaultPage() {
       return <div>파트를 선택해주세요.</div>;
     }
 
-    // localStorage에서 선택된 파트의 포트폴리오 데이터 가져오기
-    const partData = getStoredPortfolioData(selectedPart);
+    // 서버 데이터가 있으면 우선 사용, 없으면 localStorage에서 가져오기
+    let partData = null;
+    if (Object.keys(partProfiles).length > 0) {
+      const convertedData = convertServerDataToViewData(selectedPart, partProfiles);
+      if (convertedData) {
+        partData = {
+          ...convertedData,
+          name: name,
+          intro: intro,
+          dbtiInfo: dbtiInfo,
+          profileImage: profileImage,
+        };
+      }
+    }
+    
+    // 서버 데이터가 없으면 localStorage에서 가져오기
+    if (!partData) {
+      partData = getStoredPortfolioData(selectedPart);
+    }
 
     if (!partData) {
       return <div>{selectedPart} 포트폴리오 데이터를 찾을 수 없습니다.</div>;
     }
 
+    // 수정 모드인 경우 Form 컴포넌트 표시
+    if (selectedPart && isEditMode[selectedPart]) {
+      switch (selectedPart) {
+        case "PM":
+          return (
+            <PMPortfolioForm
+              name={name}
+              intro={intro}
+              dbtiInfo={dbtiInfo}
+              profileImage={profileImage}
+              selectedParts={selectedParts}
+              portfolioData={{
+                experienceSummary: partData.experienceSummary || "",
+                strengths: partData.strengths || "",
+                dailyAvailability: partData.dailyAvailability || null,
+                weeklyAvailability: partData.weeklyAvailability || null,
+                designAssessment: partData.designAssessment || {},
+                developmentAssessment: partData.developmentAssessment || {},
+                isNewcomer: partData.isNewcomer || false,
+              }}
+              onRegister={() => {
+                setIsEditMode((prev) => ({
+                  ...prev,
+                  [selectedPart]: false,
+                }));
+                return selectedParts;
+              }}
+            />
+          );
+        case "디자인":
+          return (
+            <DesignPortfolioForm
+              name={name}
+              intro={intro}
+              dbtiInfo={dbtiInfo}
+              profileImage={profileImage}
+              selectedParts={selectedParts}
+              portfolioData={{
+                experienceSummary: partData.experienceSummary || "",
+                strengths: partData.strengths || "",
+                designWorkFile: partData.designWorkFile || null,
+                figmaAssessment: partData.figmaAssessment || {},
+                isNewcomer: partData.isNewcomer || false,
+              }}
+              onRegister={() => {
+                setIsEditMode((prev) => ({
+                  ...prev,
+                  [selectedPart]: false,
+                }));
+                return selectedParts;
+              }}
+            />
+          );
+        case "프론트엔드":
+          return (
+            <FrontendPortfolioForm
+              name={name}
+              intro={intro}
+              dbtiInfo={dbtiInfo}
+              profileImage={profileImage}
+              selectedParts={selectedParts}
+              portfolioData={{
+                experienceSummary: partData.experienceSummary || "",
+                strengths: partData.strengths || "",
+                github: partData.github || "",
+                selectedTechs: partData.selectedTechs || [],
+                techAssessments: partData.techAssessments || {},
+                isNewcomer: partData.isNewcomer || false,
+              }}
+              onRegister={() => {
+                setIsEditMode((prev) => ({
+                  ...prev,
+                  [selectedPart]: false,
+                }));
+                return selectedParts;
+              }}
+            />
+          );
+        case "백엔드":
+          return (
+            <BackendPortfolioForm
+              name={name}
+              intro={intro}
+              dbtiInfo={dbtiInfo}
+              profileImage={profileImage}
+              selectedParts={selectedParts}
+              portfolioData={{
+                experienceSummary: partData.experienceSummary || "",
+                strengths: partData.strengths || "",
+                github: partData.github || "",
+                selectedTechs: partData.selectedTechs || [],
+                techAssessments: partData.techAssessments || {},
+                isNewcomer: partData.isNewcomer || false,
+              }}
+              onRegister={() => {
+                setIsEditMode((prev) => ({
+                  ...prev,
+                  [selectedPart]: false,
+                }));
+                return selectedParts;
+              }}
+            />
+          );
+        default:
+          return null;
+      }
+    }
+
+    // View 모드인 경우 View 컴포넌트 표시
     switch (selectedPart) {
       case "PM":
         return (

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -167,33 +167,32 @@ export default function ProfilePage() {
               setPartProfiles(partProfilesData);
               
               // 프로필 데이터가 있으면 default 페이지로 이동
-              // TODO: POST 테스트용 임시 주석 처리 - 테스트 후 복구 필요
-              // if (Object.keys(partProfilesData).length > 0) {
-              //   // 서버에서 가져온 데이터를 ProfileDefaultPage 형식으로 변환
-              //   const partMap: Record<string, PartOption> = {
-              //     'PM': 'PM',
-              //     'FE': '프론트엔드',
-              //     'BE': '백엔드',
-              //     'DE': '디자인'
-              //   };
-              //   
-              //   // 첫 번째 파트를 기본 선택 파트로 설정
-              //   const firstPart = profileData.available_parts[0];
-              //   const firstPartOption = partMap[firstPart];
-              //   
-              //   navigate('/profile/Default', {
-              //     state: {
-              //       name: profileData.username,
-              //       intro: profileData.comment,
-              //       dbtiInfo: null, // DBTI는 별도로 가져와야 할 수 있음
-              //       profileImage: null, // 프로필 이미지는 별도로 가져와야 할 수 있음
-              //       selectedParts: mappedParts,
-              //       part: firstPartOption,
-              //       partProfiles: partProfilesData, // 각 파트별 프로필 데이터
-              //       commonProfile: profileData, // 공통 프로필 데이터
-              //     },
-              //   });
-              // }
+              if (Object.keys(partProfilesData).length > 0) {
+                // 서버에서 가져온 데이터를 ProfileDefaultPage 형식으로 변환
+                const partMap: Record<string, PartOption> = {
+                  'PM': 'PM',
+                  'FE': '프론트엔드',
+                  'BE': '백엔드',
+                  'DE': '디자인'
+                };
+                
+                // 첫 번째 파트를 기본 선택 파트로 설정
+                const firstPart = profileData.available_parts[0];
+                const firstPartOption = partMap[firstPart];
+                
+                navigate('/profile/Default', {
+                  state: {
+                    name: profileData.username,
+                    intro: profileData.comment,
+                    dbtiInfo: null, // DBTI는 별도로 가져와야 할 수 있음
+                    profileImage: null, // 프로필 이미지는 별도로 가져와야 할 수 있음
+                    selectedParts: mappedParts,
+                    part: firstPartOption,
+                    partProfiles: partProfilesData, // 각 파트별 프로필 데이터
+                    commonProfile: profileData, // 공통 프로필 데이터
+                  },
+                });
+              }
             }
           }
         } catch (error) {

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,227 @@
+import axiosInstance from "@/lib/AxiosInstance";
+
+type PartType = "PM" | "FE" | "BE" | "DE";
+
+// 공통 프로필 응답 타입
+interface CommonProfileResponse {
+  username: string;
+  email: string;
+  devti: string;
+  comment: string;
+  available_parts: PartType[];
+}
+
+// PM 프로필 응답 타입
+interface PMProfileResponse extends CommonProfileResponse {
+  part: "PM";
+  experienced: string;
+  strength: string;
+  daily_time_capacity: number;
+  weekly_time_capacity: number;
+  design_understanding: number;
+  development_understanding: number;
+}
+
+// FE 프로필 응답 타입
+interface FEProfileResponse extends CommonProfileResponse {
+  part: "FE";
+  experienced: string;
+  strength: string;
+  github_url: string;
+  development_score: [string, number][]; // [["리액트", 4.5], ...]
+}
+
+// BE 프로필 응답 타입
+interface BEProfileResponse extends CommonProfileResponse {
+  part: "BE";
+  experienced: string;
+  strength: string;
+  github_url: string;
+  development_score: [string, number][]; // [["스프링부트", 5.0], ...]
+}
+
+// DE 프로필 응답 타입
+interface DEProfileResponse extends CommonProfileResponse {
+  part: "DE";
+  experienced: string | null;
+  strength: string;
+  portfolio_url: string;
+  design_score: number;
+}
+
+// 프로필 응답 타입 (유니온)
+type ProfileResponse =
+  | CommonProfileResponse
+  | PMProfileResponse
+  | FEProfileResponse
+  | BEProfileResponse
+  | DEProfileResponse;
+
+// 공통 프로필 업데이트 요청 타입
+interface CommonProfileUpdateRequest {
+  username?: string;
+  comment?: string;
+}
+
+// PM 프로필 업데이트 요청 타입
+interface PMProfileUpdateRequest {
+  experienced?: string | null; // 신입인 경우 null 전송
+  strength?: string | string[]; // 스웨거 스펙에 따라 배열도 허용
+  daily_time_capacity?: number;
+  weekly_time_capacity?: number;
+  design_understanding?: number;
+  development_understanding?: number;
+}
+
+// FE 프로필 업데이트 요청 타입
+interface FEProfileUpdateRequest {
+  experienced?: string | null; // 신입인 경우 null 전송
+  strength?: string | string[]; // 스웨거 스펙에 따라 배열도 허용
+  github_url?: string;
+  development_score?: [string, number][] | string; // 배열 또는 "상"
+}
+
+// BE 프로필 업데이트 요청 타입
+interface BEProfileUpdateRequest {
+  experienced?: string | null; // 신입인 경우 null 전송
+  strength?: string | string[]; // 스웨거 스펙에 따라 배열도 허용
+  github_url?: string;
+  development_score?: [string, number][];
+}
+
+// DE 프로필 업데이트 요청 타입
+interface DEProfileUpdateRequest {
+  experienced?: string | null; // 신입인 경우 null 전송
+  strength?: string | string[]; // 스웨거 스펙에 따라 배열도 허용
+  portfolio_url?: string;
+  design_score?: number;
+}
+
+// 프로필 업데이트 요청 타입 (유니온)
+type ProfileUpdateRequest =
+  | CommonProfileUpdateRequest
+  | PMProfileUpdateRequest
+  | FEProfileUpdateRequest
+  | BEProfileUpdateRequest
+  | DEProfileUpdateRequest;
+
+const handleProfileError = (error: any, defaultMessage: string) => {
+  const data = error?.response?.data;
+  if (data) {
+    // 상세 에러 정보를 콘솔에 출력
+    console.error("서버 에러 응답:", JSON.stringify(data, null, 2));
+    const msg =
+      data.message ||
+      data.detail?.non_field_errors?.[0] ||
+      data.detail ||
+      defaultMessage;
+    return typeof msg === "string" ? msg : JSON.stringify(msg);
+  }
+  return error?.message || defaultMessage;
+};
+
+// GET /api/profile
+// part가 없으면 기본 프로필, 있으면 해당 파트 프로필 반환
+export const getProfile = async (part?: PartType) => {
+  try {
+    const response = await axiosInstance.get("/api/profile", {
+      params: part ? { part } : undefined,
+    });
+
+    if (response.data?.status === "success") {
+      return { success: true, data: response.data.data as ProfileResponse };
+    }
+    return { success: false, error: "프로필 조회에 실패했습니다" };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: handleProfileError(error, "프로필 조회에 실패했습니다"),
+    };
+  }
+};
+
+// POST /api/profile
+export const createProfile = async (
+  data: ProfileUpdateRequest | FormData,
+  part: PartType
+) => {
+  try {
+    // FormData인 경우 (파일 업로드가 필요한 경우)
+    if (data instanceof FormData) {
+      const response = await axiosInstance.post("/api/profile/", data, {
+        params: { part },
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      if (response.data?.status === "success") {
+        return { success: true, data: response.data.data as ProfileResponse };
+      }
+      return { success: false, error: "프로필 생성에 실패했습니다", statusCode: response.status };
+    } else {
+      // 일반 객체인 경우 (JSON)
+      const response = await axiosInstance.post("/api/profile/", data, {
+        params: { part },
+      });
+
+      if (response.data?.status === "success") {
+        return { success: true, data: response.data.data as ProfileResponse };
+      }
+      return { success: false, error: "프로필 생성에 실패했습니다", statusCode: response.status };
+    }
+  } catch (error: any) {
+    const statusCode = error?.response?.status;
+    return {
+      success: false,
+      error: handleProfileError(error, "프로필 생성에 실패했습니다"),
+      statusCode,
+    };
+  }
+};
+
+// PUT /api/profile
+// part가 없으면 공통 프로필 수정, 있으면 해당 파트 프로필 수정
+export const updateProfile = async (
+  data: ProfileUpdateRequest | FormData,
+  part?: PartType
+) => {
+  try {
+    // 토큰 확인
+    const token = localStorage.getItem('access_token');
+    console.log("토큰 존재 여부:", !!token);
+    console.log("PUT 요청:", "/api/profile/", { part, data });
+    
+    // FormData인 경우 (파일 업로드가 필요한 경우)
+    if (data instanceof FormData) {
+      const response = await axiosInstance.put("/api/profile/", data, {
+        params: part ? { part } : undefined,
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      if (response.data?.status === "success") {
+        return { success: true, data: response.data.data as ProfileResponse };
+      }
+      return { success: false, error: "프로필 업데이트에 실패했습니다", statusCode: response.status };
+    } else {
+      // 일반 객체인 경우 (JSON)
+      const response = await axiosInstance.put("/api/profile/", data, {
+        params: part ? { part } : undefined,
+      });
+
+      if (response.data?.status === "success") {
+        return { success: true, data: response.data.data as ProfileResponse };
+      }
+      return { success: false, error: "프로필 업데이트에 실패했습니다", statusCode: response.status };
+    }
+  } catch (error: any) {
+    const statusCode = error?.response?.status;
+    return {
+      success: false,
+      error: handleProfileError(error, "프로필 업데이트에 실패했습니다"),
+      statusCode,
+    };
+  }
+};


### PR DESCRIPTION
## Description
프로필 API 연동

## Changes
- **프로필 생성/수정 로직 개선**: 프로필 존재 여부를 확인하여 POST/PUT 자동 선택
  - 프로필이 없을 때: `createProfile` (POST) 사용
  - 프로필이 있을 때: `updateProfile` (PUT) 사용
  
- **디자인 포트폴리오 파일 업로드 개선**
  - 항상 FormData 사용 (multipart/form-data)
  - 파일이 없을 때도 빈 문자열 전송하여 오류 방지
  - 파일이 있으면 파일 객체, 없으면 빈 문자열 또는 기존 URL 전송

- **HTTP 헤더 설정**
  - PUT 요청에 multipart/form-data 헤더 명시적 설정

- **프로필 리다이렉트 로직 복구(fix: restore profile redirect logic 커밋)**: 프로필이 있을 때 자동으로 default 페이지로 이동하는 로직 복구


## Files Changed
- `src/services/profile.ts` - 프로필 API 서비스 함수
- `src/components/profile/DesignPortfolioForm.tsx` - 디자인 포트폴리오 폼
- `src/components/profile/PMPortfolioForm.tsx` - PM 포트폴리오 폼
- `src/components/profile/FrontendPortfolioForm.tsx` - 프론트엔드 포트폴리오 폼
- `src/components/profile/BackendPortfolioForm.tsx` - 백엔드 포트폴리오 폼
- `src/pages/profile/ProfilePage.tsx` -프로필페이지

## Testing
-  프로필이 없을 때 POST 요청으로 생성되는지 확인
- 프로필이 있을 때 PUT 요청으로 업데이트되는지 확인
- 디자인 포트폴리오 파일 업로드 정상 동작 확인
- 여러 파트 프로필 등록 가능한지 확인